### PR TITLE
Fix "number of disks changed" trigger prototype expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ FEATURES
 REQUIREMENTS
 ------------
 * Zabbix server version 3.0
-* SYSFS at agents`s server, __/sys/block/md*__ available
+* SYSFS at agents's server, __/sys/block/md*__ available
 
 INSTALLATION
 ------------
 * Agent
-  * Copy __userparameter_md.conf__ to __/etc/zabbix/zabbix_agentd.d/userparameter_md.conf__ 
+  * Copy __userparameter_md.conf__ to __/etc/zabbix/zabbix_agentd.d/userparameter_md.conf__
   * Restart zabbix_agent
 * Server
   * Import template __template_md.xml__ file
@@ -36,4 +36,4 @@ LICENSE
 -------
 GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
 
-@see __LICENSE__
+See [LICENSE](LICENSE)

--- a/template_md.xml
+++ b/template_md.xml
@@ -210,7 +210,7 @@
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template MD Soft RAID:md.degraded[{#MDNAME}].last()}&gt;0</expression>
-                            <name>MD {#MDNAME} is degraded  on {HOST.NAME}</name>
+                            <name>MD {#MDNAME} is degraded on {HOST.NAME}</name>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
@@ -219,8 +219,8 @@
                             <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template MD Soft RAID:md.raid_disks[{#MDNAME}].change()}&gt;0</expression>
-                            <name>MD {#MDNAME} number of disks changed  on {HOST.NAME}</name>
+                            <expression>{Template MD Soft RAID:md.raid_disks[{#MDNAME}].diff()}&gt;0</expression>
+                            <name>MD {#MDNAME} number of disks changed on {HOST.NAME}</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>


### PR DESCRIPTION
_change()_ function returns the **amount** of difference between last and previous values.
_diff()_ function returns **1** if last and previous values differ, **0** otherwise.
Reference: https://www.zabbix.com/documentation/3.2/manual/appendix/triggers/functions
I think you mean the latter. The former returned expression evaluation error in Zabbix 3.2.