### PR TITLE
fix discovery: remove partition in ubuntu

### DIFF
--- a/userparameter_md.conf
+++ b/userparameter_md.conf
@@ -1,4 +1,4 @@
-UserParameter=md.discover,ls /sys/class/block | awk 'BEGIN{printf "{\"data\":["}; /md/ {printf c"{\"{#MDNAME}\":\""$1"\"}";c=","}; END{print "]}"}'
+UserParameter=md.discover,ls /sys/class/block |grep md| grep -v p | awk 'BEGIN{printf "{\"data\":["}; /md/ {printf c"{\"{#MDNAME}\":\""$1"\"}";c=","}; END{print "]}"}'
 UserParameter=md.degraded[*],cat /sys/block/$1/md/degraded
 UserParameter=md.sync_action[*],cat /sys/block/$1/md/sync_action
 UserParameter=md.raid_disks[*],cat /sys/block/$1/md/raid_disks


### PR DESCRIPTION
Убираем лишние устройства, как минимум в ubuntu:
root@fire# cat /proc/mdstat 
Personalities : [raid6] [raid5] [raid4] [linear] [multipath] [raid0] [raid1] [raid10] 
md5 : active raid5 sdb1[0] sdc1[1] sdd1[3]
      3906762752 blocks super 1.2 level 5, 512k chunk, algorithm 2 [3/3] [UUU]
      bitmap: 7/15 pages [28KB], 65536KB chunk

unused devices: <none>
root@fire# ls /sys/class/block
loop0  loop2  loop4  loop6  md5    md5p9  sda1  sda3  sdb   sdc   sdd   sde   sde9
loop1  loop3  loop5  loop7  md5p1  sda    sda2  sda4  sdb1  sdc1  sdd1  sde1
root@fire# ls /sys/class/block |grep md| grep -v p | awk 'BEGIN{printf "{\"data\":["}; /md/ {printf c"{\"{#MDNAME}\":\""$1"\"}";c=","}; END{print "]}"}'
{"data":[{"{#MDNAME}":"md5"}]}
root@fire# ls /sys/class/block | awk 'BEGIN{printf "{\"data\":["}; /md/ {printf c"{\"{#MDNAME}\":\""$1"\"}";c=","}; END{print "]}"}'{"data":[{"{#MDNAME}":"md5"},{"{#MDNAME}":"md5p1"},{"{#MDNAME}":"md5p9"}]}